### PR TITLE
feat: Support Windows 10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
             build/*.AppImage
             build/*.tar.gz
   build-macos:
-    runs-on: macOS-latest
+    runs-on: macos-latest
 
     timeout-minutes: 30
 
@@ -190,7 +190,7 @@ jobs:
         run: |
           yarn --ignore-scripts
       - name: Setup for windows
-        run: ./setup_wcjs.ps1
+        run: pwsh ./setup_wcjs.ps1
       - name: Build
         run: |
           yarn build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,3 +160,56 @@ jobs:
           name: mac-build-image
           path: |
             build/*.dmg
+  build-windows:
+    runs-on: windows-latest
+
+    timeout-minutes: 30
+
+    strategy:
+      matrix:
+        node-version: [12.x]
+
+    needs: lint
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: Install
+        run: |
+          yarn
+      - name: Build webchimera.js
+        run: ./setup_wcjs.ps1
+      - name: Build
+        run: |
+          yarn build
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: windows-build
+          path: |
+            build
+      - name: Upload dist artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: windows-dist
+          path: |
+            dist
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: windows-build-image
+          path: |
+            build/*.exe
+            build/*.zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
       - .gitignore
       - LICENSE
       - "**.md"
+  pull_request:
 
 jobs:
   lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,8 +188,8 @@ jobs:
             ${{ runner.os }}-yarn-
       - name: Install
         run: |
-          yarn
-      - name: Build webchimera.js
+          yarn --ignore-scripts
+      - name: Setup for windows
         run: ./setup_wcjs.ps1
       - name: Build
         run: |

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Electron を使用した Mirakurun の映像視聴確認用アプリです。鋭
 
 ### 安定版
 
-macOS / Linux 版ビルドを [Releases](https://github.com/ci7lus/MirakTest/releases) にて配布しています。
+macOS / Linux / Windows 版ビルドを [Releases](https://github.com/ci7lus/MirakTest/releases) にて配布しています。
 
 #### macOS での実行
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ yarn build
 ### Windows
 
 ```powershell
-choco install -y cmake
+choco install -y cmake powershell-core
 git clone git@github.com:ci7lus/MirakTest.git
 cd MirakTest
 yarn

--- a/README.md
+++ b/README.md
@@ -69,6 +69,17 @@ yarn
 yarn build
 ```
 
+### Windows
+
+```powershell
+choco install -y cmake
+git clone git@github.com:ci7lus/MirakTest.git
+cd MirakTest
+yarn
+./setup_wcjs.ps1
+yarn build
+```
+
 ## 謝辞
 
 MirakTest は次のプロジェクトを利用/参考にして実装しています。

--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ yarn build
 choco install -y cmake powershell-core
 git clone git@github.com:ci7lus/MirakTest.git
 cd MirakTest
-yarn
-./setup_wcjs.ps1
+yarn --ignore-scripts
+pwsh ./setup_wcjs.ps1
 yarn build
 ```
 

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,4 +1,4 @@
-appId: io.github.ci7lus.miraktest
+﻿appId: io.github.ci7lus.miraktest
 productName: MirakTest
 copyright: Copyright © 2021 ci7lus
 directories:
@@ -205,7 +205,6 @@ publish: null
 npmRebuild: false
 npmArgs: "--runtime=node "
 afterPack: "./dist/afterpack.js"
-electronVersion: "11.1.0"
 mac:
   icon: "assets/miraktest.icns"
   entitlements: "entitlements.plist"

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -205,6 +205,7 @@ publish: null
 npmRebuild: false
 npmArgs: "--runtime=node "
 afterPack: "./dist/afterpack.js"
+electronVersion: "11.1.0"
 mac:
   icon: "assets/miraktest.icns"
   entitlements: "entitlements.plist"

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,4 +1,4 @@
-﻿appId: io.github.ci7lus.miraktest
+appId: io.github.ci7lus.miraktest
 productName: MirakTest
 copyright: Copyright © 2021 ci7lus
 directories:

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
-{
+﻿{
   "name": "miraktest",
   "productName": "MirakTest",
   "version": "1.3.0",
-  "description": "Mirakurun 映像視聴確認用アプリ",
+  "description": "Mirakurun 譏蜒剰ｦ冶・遒ｺ隱咲畑繧｢繝励Μ",
   "author": "ci7lus <7887955+ci7lus@users.noreply.github.com>",
   "license": "MIT",
   "repository": {
@@ -44,7 +44,7 @@
     "babel-loader": "^8.2.2",
     "cross-env": "^7.0.3",
     "css-loader": "^5.1.3",
-    "electron": "^11.1.0",
+    "electron": "^12.0.1",
     "electron-builder": "^22.10.5",
     "jest": "^26.6.3",
     "mini-css-extract-plugin": "^1.3.9",
@@ -82,7 +82,7 @@
   },
   "cmake-js": {
     "runtime": "electron",
-    "runtimeVersion": "11.1.0"
+    "runtimeVersion": "12.0.1"
   },
-  "browserslist": "electron 11.1.0"
+  "browserslist": "electron 12.0.1"
 }

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
-﻿{
+{
   "name": "miraktest",
   "productName": "MirakTest",
   "version": "1.3.0",
-  "description": "Mirakurun 譏蜒剰ｦ冶・遒ｺ隱咲畑繧｢繝励Μ",
+  "description": "Mirakurun 映像視聴確認用アプリ",
   "author": "ci7lus <7887955+ci7lus@users.noreply.github.com>",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -11,11 +11,11 @@
   },
   "main": "dist/index.electron.js",
   "scripts": {
-    "dev:electron": "NODE_ENV=development electron .",
+    "dev:electron": "cross-env NODE_ENV=development electron .",
     "dev:webpack": "webpack --mode development --color -w",
     "build:electron": "electron-builder",
     "build:tsc": "tsc --build tsconfig.tsc.json",
-    "build:webpack": "NODE_ENV=production webpack --mode production",
+    "build:webpack": "cross-env NODE_ENV=production webpack --mode production",
     "build": "yarn build:webpack && yarn build:tsc && yarn build:electron",
     "lint": "prettier --check './src/**/*.{js,ts,tsx}'",
     "format": "prettier --write './src/**/*.{js,ts,tsx}'"
@@ -42,8 +42,9 @@
     "@yarnpkg/lockfile": "^1.1.0",
     "autoprefixer": "^10.2.5",
     "babel-loader": "^8.2.2",
+    "cross-env": "^7.0.3",
     "css-loader": "^5.1.3",
-    "electron": "^12.0.1",
+    "electron": "^11.1.0",
     "electron-builder": "^22.10.5",
     "jest": "^26.6.3",
     "mini-css-extract-plugin": "^1.3.9",
@@ -81,7 +82,7 @@
   },
   "cmake-js": {
     "runtime": "electron",
-    "runtimeVersion": "12.0.1"
+    "runtimeVersion": "11.1.0"
   },
-  "browserslist": "electron 12.0.1"
+  "browserslist": "electron 11.1.0"
 }

--- a/setup_wcjs.ps1
+++ b/setup_wcjs.ps1
@@ -36,7 +36,7 @@ module.exports = {
 Set-Location ".."
 
 # Setup Electron 11
-yarn add -D electron@^11
+yarn add -D electron@11.1.0 --ignore-scripts
 InsertAfter ".\electron-builder.yml" "^afterPack" "electronVersion: `"11.1.0`""
 ReplaceOne ".\package.json" "`"browserslist`": .+" "`"browserslist`": `"electron 11.1.0`""
 ReplaceOne ".\package.json" "`"runtimeVersion`": .+" "`"runtimeVersion`": `"11.1.0`""

--- a/setup_wcjs.ps1
+++ b/setup_wcjs.ps1
@@ -5,17 +5,38 @@ $RUNTIME_VER = "11.1.0"
 $VLC_VER = "3.0.11"
 $WCJS_VER = "0.3.1"
 
+function InsertAfter ([string]$file, [string]$needle, [string]$text, [string]$encoding = 'UTF8') {
+    $data = Get-Content "$file"
+    $lnum = $(Select-String -pattern "$needle" -path "$file" | ForEach-Object { $_.ToString().split(":")[2] } ) - 1
+    If ($lnum -ne -1) {
+        $data[$lnum] = $data[$lnum] + "`n$text"
+        $data | Out-File "$file" -Encoding "$encoding"
+    }
+}
+
+function ReplaceOne ([string]$file, [string]$needle, [string]$text, [string]$encoding = 'UTF8') {
+    $data = Get-Content "$file" | ForEach-Object { $_ -replace "$needle", "$text" }
+    $data | Out-File "$file" -Encoding "$encoding"
+}
+
+# Setup WebChimera.js
 Set-Location "node_modules"
 
 Invoke-WebRequest -Uri "https://github.com/RSATom/WebChimera.js/releases/download/v${WCJS_VER}/WebChimera.js_v${WCJS_VER}_${RUNTIME}_v${RUNTIME_VER}_VLC_v${VLC_VER}_${ARCH}_${OS_NAME}.zip" -OutFile "wcjs.zip"
-Expand-Archive -Path "wcjs.zip" -DestinationPath "." -Force
-Remove-Item "wcjs.zip"
+Expand-Archive -Path ".\wcjs.zip" -DestinationPath "." -Force
+Remove-Item ".\wcjs.zip"
 
 @"
 module.exports = {
     ...require('./WebChimera.js.node'),
     path: __dirname.replace('app.asar', 'app.asar.unpacked')
 }
-"@ | Set-Content "webchimera.js/index.js" -Encoding UTF8
+"@ | Set-Content ".\webchimera.js\index.js" -Encoding UTF8
 
 Set-Location ".."
+
+# Setup Electron 11
+yarn add -D electron@^11
+InsertAfter ".\electron-builder.yml" "^afterPack" "electronVersion: `"11.1.0`""
+ReplaceOne ".\package.json" "`"browserslist`": .+" "`"browserslist`": `"electron 11.1.0`""
+ReplaceOne ".\package.json" "`"runtimeVersion`": .+" "`"runtimeVersion`": `"11.1.0`""

--- a/setup_wcjs.ps1
+++ b/setup_wcjs.ps1
@@ -5,7 +5,7 @@ $RUNTIME_VER = "11.1.0"
 $VLC_VER = "3.0.11"
 $WCJS_VER = "0.3.1"
 
-function InsertAfter ([string]$file, [string]$needle, [string]$text, [string]$encoding = 'UTF8') {
+function InsertAfter ([string]$file, [string]$needle, [string]$text, [string]$encoding = "utf8NoBOM") {
     $data = Get-Content "$file"
     $lnum = $(Select-String -pattern "$needle" -path "$file" | ForEach-Object { $_.ToString().split(":")[2] } ) - 1
     If ($lnum -ne -1) {
@@ -14,29 +14,27 @@ function InsertAfter ([string]$file, [string]$needle, [string]$text, [string]$en
     }
 }
 
-function ReplaceOne ([string]$file, [string]$needle, [string]$text, [string]$encoding = 'UTF8') {
+function ReplaceOne ([string]$file, [string]$needle, [string]$text, [string]$encoding = "utf8NoBOM") {
     $data = Get-Content "$file" | ForEach-Object { $_ -replace "$needle", "$text" }
     $data | Out-File "$file" -Encoding "$encoding"
 }
 
+# Setup Electron 11
+yarn add -D --ignore-scripts electron@^11
+InsertAfter ".\electron-builder.yml" "afterPack:" "electronVersion: `"11.1.0`""
+ReplaceOne ".\package.json" "`"browserslist`": .+" "`"browserslist`": `"electron 11.1.0`""
+ReplaceOne ".\package.json" "`"runtimeVersion`": .+" "`"runtimeVersion`": `"11.1.0`""
+
 # Setup WebChimera.js
 Set-Location "node_modules"
-
 Invoke-WebRequest -Uri "https://github.com/RSATom/WebChimera.js/releases/download/v${WCJS_VER}/WebChimera.js_v${WCJS_VER}_${RUNTIME}_v${RUNTIME_VER}_VLC_v${VLC_VER}_${ARCH}_${OS_NAME}.zip" -OutFile "wcjs.zip"
 Expand-Archive -Path ".\wcjs.zip" -DestinationPath "." -Force
 Remove-Item ".\wcjs.zip"
-
 @"
-module.exports = {
-    ...require('./WebChimera.js.node'),
-    path: __dirname.replace('app.asar', 'app.asar.unpacked')
-}
-"@ | Set-Content ".\webchimera.js\index.js" -Encoding UTF8
+    module.exports = {
+        ...require('./WebChimera.js.node'),
+        path: __dirname.replace('app.asar', 'app.asar.unpacked')
+    }
+"@ | Set-Content ".\webchimera.js\index.js"
 
 Set-Location ".."
-
-# Setup Electron 11
-yarn add -D electron@11.1.0 --ignore-scripts
-InsertAfter ".\electron-builder.yml" "^afterPack" "electronVersion: `"11.1.0`""
-ReplaceOne ".\package.json" "`"browserslist`": .+" "`"browserslist`": `"electron 11.1.0`""
-ReplaceOne ".\package.json" "`"runtimeVersion`": .+" "`"runtimeVersion`": `"11.1.0`""

--- a/setup_wcjs.ps1
+++ b/setup_wcjs.ps1
@@ -1,0 +1,21 @@
+$ARCH = "x64"
+$OS_NAME = "win"
+$RUNTIME = "electron"
+$RUNTIME_VER = "11.1.0"
+$VLC_VER = "3.0.11"
+$WCJS_VER = "0.3.1"
+
+Set-Location "node_modules"
+
+Invoke-WebRequest -Uri "https://github.com/RSATom/WebChimera.js/releases/download/v${WCJS_VER}/WebChimera.js_v${WCJS_VER}_${RUNTIME}_v${RUNTIME_VER}_VLC_v${VLC_VER}_${ARCH}_${OS_NAME}.zip" -OutFile "wcjs.zip"
+Expand-Archive -Path "wcjs.zip" -DestinationPath "." -Force
+Remove-Item "wcjs.zip"
+
+@"
+module.exports = {
+    ...require('./WebChimera.js.node'),
+    path: __dirname.replace('app.asar', 'app.asar.unpacked')
+}
+"@ | Set-Content "webchimera.js/index.js" -Encoding UTF8
+
+Set-Location ".."

--- a/setup_wcjs.ps1
+++ b/setup_wcjs.ps1
@@ -10,13 +10,13 @@ function InsertAfter ([string]$file, [string]$needle, [string]$text, [string]$en
     $lnum = $(Select-String -pattern "$needle" -path "$file" | ForEach-Object { $_.ToString().split(":")[2] } ) - 1
     If ($lnum -ne -1) {
         $data[$lnum] = $data[$lnum] + "`n$text"
-        $data | Out-File "$file" -Encoding "$encoding"
+        $data -Join "`n" | Out-File "$file" -Encoding "$encoding" -NoNewline
     }
 }
 
 function ReplaceOne ([string]$file, [string]$needle, [string]$text, [string]$encoding = "utf8NoBOM") {
     $data = Get-Content "$file" | ForEach-Object { $_ -replace "$needle", "$text" }
-    $data | Out-File "$file" -Encoding "$encoding"
+    $data -Join "`n" | Out-File "$file" -Encoding "$encoding" -NoNewline
 }
 
 # Setup Electron 11

--- a/src/@types/webchimera.d.ts
+++ b/src/@types/webchimera.d.ts
@@ -49,4 +49,5 @@ declare module "webchimera.js" {
     subtitles: VLCSubtitle
   }
   export const createPlayer: () => Player
+  export const path: string | undefined
 }

--- a/src/index.electron.ts
+++ b/src/index.electron.ts
@@ -2,10 +2,17 @@ import { app, BrowserWindow, screen, ipcMain } from "electron"
 import path from "path"
 import Store from "electron-store"
 import RPC from "discord-rpc"
+import WebChimeraJs from "webchimera.js"
 
 let window: BrowserWindow | null = null
 
 const init = () => {
+  if (process.platform == "win32" && WebChimeraJs.path) {
+    const VLCPluginPath = path.join(WebChimeraJs.path, "plugins")
+    console.log("win32 detected, VLC_PLUGIN_PATH:", VLCPluginPath)
+    process.env["VLC_PLUGIN_PATH"] = VLCPluginPath
+  }
+
   Store.initRenderer()
   const display = screen.getPrimaryDisplay()
   window = new BrowserWindow({

--- a/tsconfig.tsc.json
+++ b/tsconfig.tsc.json
@@ -69,6 +69,10 @@
     "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */,
     "resolveJsonModule": true
   },
-  "include": ["src/index.electron.ts", "src/afterpack.ts"],
+  "include": [
+    "src/index.electron.ts",
+    "src/afterpack.ts",
+    "src/@types/webchimera.d.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1385,10 +1385,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.35.tgz#42c953a4e2b18ab931f72477e7012172f4ffa313"
   integrity sha512-Lt+wj8NVPx0zUmUwumiVXapmaLUcAk3yPuHCFVXras9k5VT9TdhJqKqGVUQCD60OTMCl0qxJ57OiTL0Mic3Iag==
 
-"@types/node@^12.0.12":
-  version "12.20.10"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.10.tgz#4dcb8a85a8f1211acafb88d72fafc7e3d2685583"
-  integrity sha512-TxCmnSSppKBBOzYzPR2BR25YlX5Oay8z2XGwFBInuA/Co0V9xJhLlW4kjbxKtgeNo3NOMbQP1A5Rc03y+XecPw==
+"@types/node@^14.6.2":
+  version "14.14.42"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.42.tgz#20271ce899f35eb6cd525f500bfa8f4c9e27ecd6"
+  integrity sha512-88QoObqn9WYIUMRzOx92GmSHmU3JCyukC2ulEv8tFjUG9VeV2FQ/cA7VQ1gi+rB/+gBMVvzVFcTnz8RdMDVIWw==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
@@ -3232,13 +3232,13 @@ electron-to-chromium@^1.3.649:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.690.tgz#54df63ec42fba6b8e9e05fe4be52caeeedb6e634"
   integrity sha512-zPbaSv1c8LUKqQ+scNxJKv01RYFkVVF1xli+b+3Ty8ONujHjAMg+t/COmdZqrtnS1gT+g4hbSodHillymt1Lww==
 
-electron@^11.1.0:
-  version "11.4.3"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-11.4.3.tgz#74319635417c24fd19e31cfce5a39c8792e4014b"
-  integrity sha512-RhCWJqiYK5oIRGOheilhg/nngCgk0fPgaf00KvbxorlvFZAz8OeMT5ShCpVsMSoyYhk4XEnn4orRly5ltaFYJg==
+electron@^12.0.1:
+  version "12.0.5"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-12.0.5.tgz#005cf4375d2ee4563f5e75dc4da4ef871846a8be"
+  integrity sha512-z0xYB3sPr0qZcDrHUUWqooPKe3yUzBDxQcgQe3f2TLstA84JIFXBoaIJCPh/fJW0+JdF/ZFVeK2SNgLhYtRV+Q==
   dependencies:
     "@electron/get" "^1.0.1"
-    "@types/node" "^12.0.12"
+    "@types/node" "^14.6.2"
     extract-zip "^1.0.3"
 
 emittery@^0.7.1:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1380,10 +1380,15 @@
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
 
-"@types/node@*", "@types/node@^14.6.2":
+"@types/node@*":
   version "14.14.35"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.35.tgz#42c953a4e2b18ab931f72477e7012172f4ffa313"
   integrity sha512-Lt+wj8NVPx0zUmUwumiVXapmaLUcAk3yPuHCFVXras9k5VT9TdhJqKqGVUQCD60OTMCl0qxJ57OiTL0Mic3Iag==
+
+"@types/node@^12.0.12":
+  version "12.20.10"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.10.tgz#4dcb8a85a8f1211acafb88d72fafc7e3d2685583"
+  integrity sha512-TxCmnSSppKBBOzYzPR2BR25YlX5Oay8z2XGwFBInuA/Co0V9xJhLlW4kjbxKtgeNo3NOMbQP1A5Rc03y+XecPw==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
@@ -2793,6 +2798,13 @@ create-require@^1.1.0:
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
+cross-env@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"
+  integrity sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
+  dependencies:
+    cross-spawn "^7.0.1"
+
 cross-spawn@^6.0.0:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
@@ -3220,13 +3232,13 @@ electron-to-chromium@^1.3.649:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.690.tgz#54df63ec42fba6b8e9e05fe4be52caeeedb6e634"
   integrity sha512-zPbaSv1c8LUKqQ+scNxJKv01RYFkVVF1xli+b+3Ty8ONujHjAMg+t/COmdZqrtnS1gT+g4hbSodHillymt1Lww==
 
-electron@^12.0.1:
-  version "12.0.1"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-12.0.1.tgz#11afa81dae858cc7cd79107c2f789e8a7f93a31b"
-  integrity sha512-4bTfLSTmuFkMxq3RMyjd8DxuzbxI1Bde879XDrBA4kFWbKhZ3hfXqHXQz3129eCmcLre5odcNsWq7/xzyJilMA==
+electron@^11.1.0:
+  version "11.4.3"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-11.4.3.tgz#74319635417c24fd19e31cfce5a39c8792e4014b"
+  integrity sha512-RhCWJqiYK5oIRGOheilhg/nngCgk0fPgaf00KvbxorlvFZAz8OeMT5ShCpVsMSoyYhk4XEnn4orRly5ltaFYJg==
   dependencies:
     "@electron/get" "^1.0.1"
-    "@types/node" "^14.6.2"
+    "@types/node" "^12.0.12"
     extract-zip "^1.0.3"
 
 emittery@^0.7.1:


### PR DESCRIPTION
## 現在の master での問題

- WebChimera.js をビルドできない
  - 調査中だが原因不明
  - ただし以下の問題の解決のために pre-built binary を使う必要があるのでビルドが通らなくても問題はない
- Electron 12 と WebChimera v0.3.1b だと Windows ではクラッシュする
  - https://github.com/RSATom/WebChimera.js/issues/141
- libvlc の互換性問題で `plugins` のパスを解決できない
  - https://github.com/RSATom/WebChimera.js/issues/59
- npm scripts 内で Windows だと非互換な方法で環境変数を定義している

## この PR での変更

- Electron 11.1.0 にダウングレード
- WebChimera.js のセットアップをするスクリプトを追加
  - pre-built binary をダウンロードし配置
  - `plugins` パスの解決のため `index.js` にパッチ適用
- Win32 環境の場合は `VLC_PLUGIN_PATH` を設定するように修正
- cross-env  で環境変数を設定するように修正
