### PR TITLE
aribb24.jsによる字幕表示

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
         run: |
           wget https://github.com/vivid-lapin/vlc-miraktest/releases/download/3.0.14.1/vlc-3.0.14.dmg -O /tmp/vlc.dmg
           hdiutil mount /tmp/vlc.dmg
-          cp -Ra "/Volumes/VLC media player/VLC.app" .
+          cp -Ra "/Volumes/VLC media player/VLC.app" /Applications
       - name: Install
         run: yarn
       - name: Build webchimera.js

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
       matrix:
         node-version: [12.x]
 
+    if: ${{ github.event_name != 'pull_request' || github.repository_owner != 'ci7lus' }}
+
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
@@ -60,6 +62,8 @@ jobs:
         node-version: [12.x]
 
     needs: lint
+
+    if: ${{ github.event_name != 'pull_request' || github.repository_owner != 'ci7lus' }}
 
     steps:
       - uses: actions/checkout@v2
@@ -113,6 +117,8 @@ jobs:
         node-version: [12.x]
 
     needs: lint
+
+    if: ${{ github.event_name != 'pull_request' || github.repository_owner != 'ci7lus' }}
 
     steps:
       - uses: actions/checkout@v2
@@ -169,6 +175,8 @@ jobs:
         node-version: [12.x]
 
     needs: lint
+
+    if: ${{ github.event_name != 'pull_request' || github.repository_owner != 'ci7lus' }}
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
       - name: Install deps
-        run: sudo apt-get install build-essential cmake libvlc-dev
+        run: sudo apt-get install cmake=3.16.3-1ubuntu1 libvlc-dev=3.0.9.2-1
       - name: Install
         run: yarn
       - name: Build webchimera.js

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,11 +129,11 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
-      - name: Install VLC
+      - name: Download VLC
         run: |
-          # VLC 3.0.14
-          wget https://raw.githubusercontent.com/Homebrew/homebrew-cask/d2c682daa22954206a6d608dc68e30ce13e5695f/Casks/vlc.rb
-          brew install ./vlc.rb
+          wget https://github.com/vivid-lapin/vlc-miraktest/releases/download/3.0.14.1/vlc-3.0.14.dmg -O /tmp/vlc.dmg
+          hdiutil mount /tmp/vlc.dmg
+          cp -Ra "/Volumes/VLC media player/VLC.app" .
       - name: Install
         run: yarn
       - name: Build webchimera.js

--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,4 @@ dist
 lib
 build
 vlc_libs
+VLC.app

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ Electron を使用した Mirakurun の映像視聴確認用アプリです。鋭
 
 [![Image from Gyazo](https://i.gyazo.com/582a518d615e042394ade5fe7bcfcf3f.jpg)](https://gyazo.com/582a518d615e042394ade5fe7bcfcf3f)
 
+[aribb24.js](https://github.com/monyone/aribb24.js) による字幕表示にも対応しています。
+
+[![Image from Gyazo](https://i.gyazo.com/2f5f23d3c0e2968724dd2bce018cef86.jpg)](https://gyazo.com/2f5f23d3c0e2968724dd2bce018cef86)
+
 ## 導入方法
 
 ### 安定版
@@ -26,7 +30,8 @@ macOS / Linux / Windows 版ビルドを [Releases](https://github.com/ci7lus/Mir
 #### macOS での実行
 
 dmg をマウントして app を Applications にコピーします。<br />
-Intel / M1 mac (Rosetta 2) 上で動作する macOS Catalina / Big Sur での動作を確認しています。
+Intel / M1 mac (Rosetta 2) 上で動作する macOS Catalina / Big Sur での動作を確認しています。<br />
+必須ではありませんが、字幕の表示に [Rounded M+ 1m for ARIB](https://github.com/xtne6f/TVCaptionMod2/blob/3cc6c1767595e1973473124e892a57c7693c2154/TVCaptionMod2_Readme.txt#L49-L50) を指定しているので、フォントのインストールを推奨します。[ダウンロードはこちら](https://github.com/ci7lus/MirakTest/files/6555741/rounded-mplus-1m-arib.ttf.zip)。
 
 #### Linux (debian) での実行
 
@@ -89,6 +94,7 @@ MirakTest は次のプロジェクトを利用/参考にして実装していま
 - [Chinachu/Mirakurun](https://github.com/Chinachu/Mirakurun)
 - [search-future/miyou.tv](https://github.com/search-future/miyou.tv)
 - [SlashNephy/saya](https://github.com/SlashNephy/saya)
+- [monyone/aribb24.js](https://github.com/monyone/aribb24.js)
 
 DTV コミュニティの皆さまに感謝します。
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ AppImage に実行権限をつけ `--no-sandbox` をつけて実行するか、�
 
 ## 開発
 
-メイン機能の依存として [WebChimera.js](https://github.com/RSATom/WebChimera.js) を利用しています。[Build PreRequests](https://github.com/RSATom/WebChimera.js#build-prerequisites) の導入が必要です。
+メイン機能の依存として [WebChimera.js](https://github.com/RSATom/WebChimera.js) を利用しています。[Build PreRequests](https://github.com/RSATom/WebChimera.js#build-prerequisites) の導入が必要です。<br>
 
 ### macOS
 
@@ -57,6 +57,8 @@ yarn
 ./setup_wcjs.sh
 yarn build
 ```
+
+[vlc-miraktest](https://github.com/vivid-lapin/vlc-miraktest) の [Releases](https://github.com/vivid-lapin/vlc-miraktest/releases) にある dmg から `VLC.app` を抽出し MirakTest ディレクトリに配置することで、ビルドが aribb24.js を用いるようになります。
 
 ### Linux (debian)
 

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
   "dependencies": {
     "@headlessui/react": "^1.2.0",
     "@neneka/dplayer": "^1.26.0-patch.0",
+    "aribb24.js": "^1.6.8",
     "axios": "^0.21.1",
     "dayjs": "^1.10.4",
     "discord-rpc": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   "dependencies": {
     "@headlessui/react": "^1.2.0",
     "@neneka/dplayer": "^1.26.0-patch.0",
-    "aribb24.js": "^1.6.9",
+    "aribb24.js": "^1.6.10",
     "axios": "^0.21.1",
     "dayjs": "^1.10.4",
     "discord-rpc": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "react-use": "^17.2.4",
     "recoil": "^0.3.0",
     "reconnecting-websocket": "^4.4.0",
-    "webchimera.js": "^0.5.1"
+    "webchimera.js": "^0.5.2"
   },
   "cmake-js": {
     "runtime": "electron",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   "dependencies": {
     "@headlessui/react": "^1.2.0",
     "@neneka/dplayer": "^1.26.0-patch.0",
-    "aribb24.js": "^1.6.8",
+    "aribb24.js": "^1.6.9",
     "axios": "^0.21.1",
     "dayjs": "^1.10.4",
     "discord-rpc": "^3.2.0",

--- a/setup_vlclib_mac.sh
+++ b/setup_vlclib_mac.sh
@@ -1,11 +1,17 @@
 set -eu
 rm -rf vlc_libs
-cp -Ra /Applications/VLC.app/Contents/MacOS/lib vlc_libs
+if [ -d ./VLC.app ]; then
+    BASE_PATH=./VLC.app
+else
+    BASE_PATH=/Applications/VLC.app
+fi
+echo "Using $BASE_PATH"
+cp -Ra $BASE_PATH/Contents/MacOS/lib vlc_libs
 mkdir vlc_libs/vlc
-cp -Ra /Applications/VLC.app/Contents/MacOS/{plugins,share} vlc_libs/vlc
+cp -Ra $BASE_PATH/Contents/MacOS/{plugins,share} vlc_libs/vlc
 rm -rf vlc_libs/vlc/share/locale
 rm -rf node_modules/electron/dist/Electron.app/Contents/Frameworks/libvlc*.dylib
 rm -rf node_modules/electron/dist/Electron.app/Contents/Frameworks/vlc
 for d in vlc_libs/*; do cp -Ra $d node_modules/electron/dist/Electron.app/Contents/Frameworks; done
-curl https://raw.githubusercontent.com/videolan/vlc/master/COPYING > node_modules/electron/dist/Electron.app/Contents/VLC-COPYING
-curl https://raw.githubusercontent.com/videolan/vlc/master/COPYING.LIB > node_modules/electron/dist/Electron.app/Contents/VLC-COPYING.LIB
+curl -sL https://raw.githubusercontent.com/videolan/vlc/master/COPYING > node_modules/electron/dist/Electron.app/Contents/VLC-COPYING
+curl -sL https://raw.githubusercontent.com/videolan/vlc/master/COPYING.LIB > node_modules/electron/dist/Electron.app/Contents/VLC-COPYING.LIB

--- a/setup_wcjs.sh
+++ b/setup_wcjs.sh
@@ -15,12 +15,23 @@ function finally {
 trap finally EXIT
 
 git submodule update --init --recursive
-if [ "$OS_NAME" = "Darwin" ]; then cp -Ra /Applications/VLC.app ./deps; fi
+if [ "$OS_NAME" = "Darwin" ]; then
+  if [ -d "../../VLC.app" ]; then
+    echo "Using ./VLC.app"
+    cp -Ra ../../VLC.app ./deps;
+  else
+    echo "Using /Application/VLC.app"
+    cp -Ra /Applications/VLC.app ./deps;
+  fi
+fi
 export WCJS_ARCHIVE=WebChimera.js_${npm_config_wcjs_runtime}_${npm_config_wcjs_runtime_version}_${npm_config_wcjs_arch}_${OS_NAME}.zip
 export WCJS_ARCHIVE_PATH=$BUILD_DIR/$WCJS_ARCHIVE
 export WCJS_FULL_ARCHIVE=WebChimera.js_${npm_config_wcjs_runtime}_v${npm_config_wcjs_runtime_version}_VLC_${npm_config_wcjs_arch}_${OS_NAME}.tar.gz
 if [ "$OS_NAME" = "Darwin" ]; then export WCJS_FULL_ARCHIVE_PATH=$BUILD_DIR/$WCJS_FULL_ARCHIVE; else export WCJS_FULL_ARCHIVE_PATH=$WCJS_ARCHIVE_PATH; fi
 yarn install
+if ! grep -q rebuild.js package.json; then
+  node rebuild.js
+fi
 mv ./build/Release/WebChimera.js.node .
 echo "module.exports = require('./WebChimera.js.node')" > index.js
 sed -i -e "s/node rebuild.js/echo skip rebuild/" package.json

--- a/setup_wcjs.sh
+++ b/setup_wcjs.sh
@@ -1,5 +1,5 @@
 set -eu
-export ELECTRON_VER="$(yarn info electron version --silent)"
+export ELECTRON_VER="$(yarn --silent electron --version | sed -e "s/v//")"
 export BUILD_DIR="./build/Release"
 export npm_config_wcjs_runtime=electron
 export npm_config_wcjs_runtime_version=$ELECTRON_VER

--- a/src/atoms/mainPlayer.ts
+++ b/src/atoms/mainPlayer.ts
@@ -66,6 +66,29 @@ export const mainPlayerLastSelectedServiceId = atom<number | null>({
   default: null,
 })
 
+export const mainPlayerPlayingTime = atom<number>({
+  key: `${prefix}.playingTime`,
+  default: 0,
+})
+
+export const mainPlayerAribSubtitleData = atom<{
+  data: string
+  pts: number
+} | null>({
+  key: `${prefix}.aribSubtitleData`,
+  default: null,
+})
+
+export const mainPlayerTsPts = atom<[number, number]>({
+  key: `${prefix}.mainPlayerTsPts`,
+  default: [0, 0],
+})
+
+export const mainPlayerDisplayingAribSubtitleData = atom<Uint8Array | null>({
+  key: `${prefix}.displayngAribSubtitleData`,
+  default: null,
+})
+
 export const mainPlayerScreenshotTrigger = atom<number>({
   key: `${prefix}.screenshotTrigger`,
   default: 0,

--- a/src/atoms/settings.ts
+++ b/src/atoms/settings.ts
@@ -33,6 +33,7 @@ export const screenshotSetting = atom<ScreenshotSetting>({
   key: `${prefix}.screenshot`,
   default: {
     saveAsAFile: true,
+    includeSubtitle: true,
   },
 })
 

--- a/src/components/mainPlayer/SubtitleRenderer.tsx
+++ b/src/components/mainPlayer/SubtitleRenderer.tsx
@@ -45,7 +45,7 @@ export const CoiledSubtitleRenderer: React.VFC<{}> = memo(({}) => {
     }
   }, [])
 
-  // 字幕ペイロード更新時にパースしたデータをタイムラインにプッシュする
+  // 字幕ペイロード更新時にパースしたデータをレンダリングする
   const aribSubtitleData = useRecoilValue(mainPlayerAribSubtitleData)
   const tsPts = useRecoilValue(mainPlayerTsPts)
   const playingTime = useRecoilValue(mainPlayerPlayingTime)
@@ -70,12 +70,10 @@ export const CoiledSubtitleRenderer: React.VFC<{}> = memo(({}) => {
     const ctx = canvas.getContext("2d")
     if (!ctx) return
     setTimeout(() => {
-      ctx.clearRect(0, 0, canvas.width, canvas.height)
       provider.render({
         canvas,
-        width: 1920,
-        height: 1080,
         useStrokeText: true,
+        keepAspectRatio: true,
       })
       setDisplayingAribSubtitleData(decoded)
       displayingSubtitle.current = aribSubtitleData.data
@@ -93,7 +91,7 @@ export const CoiledSubtitleRenderer: React.VFC<{}> = memo(({}) => {
     <canvas
       width={1920}
       height={1080}
-      className="absolute top-0 left-0 pointer-events-none w-full"
+      className="pointer-events-none w-full"
       style={{ height }}
       ref={canvasRef}
     ></canvas>

--- a/src/components/mainPlayer/SubtitleRenderer.tsx
+++ b/src/components/mainPlayer/SubtitleRenderer.tsx
@@ -1,0 +1,101 @@
+import React, { memo, useEffect, useRef, useState } from "react"
+import { useRecoilValue, useSetRecoilState } from "recoil"
+import {
+  mainPlayerAribSubtitleData,
+  mainPlayerDisplayingAribSubtitleData,
+  mainPlayerIsPlaying,
+  mainPlayerPlayingTime,
+  mainPlayerSubtitleEnabled,
+  mainPlayerTsPts,
+} from "../../atoms/mainPlayer"
+import { CanvasProvider } from "aribb24.js"
+import { tryBase64ToUint8Array } from "../../utils/string"
+
+export const CoiledSubtitleRenderer: React.VFC<{}> = memo(({}) => {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+
+  const subtitleEnabled = useRecoilValue(mainPlayerSubtitleEnabled)
+  const isPlaying = useRecoilValue(mainPlayerIsPlaying)
+  const setDisplayingAribSubtitleData = useSetRecoilState(
+    mainPlayerDisplayingAribSubtitleData
+  )
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+    if (subtitleEnabled === false || isPlaying === false) {
+      // 字幕オフでキャンバスをクリアする
+      canvas.getContext("2d")?.clearRect(0, 0, canvas.width, canvas.height)
+      setDisplayingAribSubtitleData(null)
+    }
+  }, [subtitleEnabled, isPlaying])
+
+  const [height, setHeight] = useState("100%")
+  // 画面リサイズ時にキャンバスも追従させる
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+    const onResize = () => {
+      const { width } = canvas.getBoundingClientRect()
+      setHeight(`${Math.ceil(width / 1.777777778)}px`)
+    }
+    onResize()
+    window.addEventListener("resize", onResize)
+    return () => {
+      window.removeEventListener("resize", onResize)
+    }
+  }, [])
+
+  // 字幕ペイロード更新時にパースしたデータをタイムラインにプッシュする
+  const aribSubtitleData = useRecoilValue(mainPlayerAribSubtitleData)
+  const tsPts = useRecoilValue(mainPlayerTsPts)
+  const playingTime = useRecoilValue(mainPlayerPlayingTime)
+  const displayingSubtitle = useRef("")
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (
+      !aribSubtitleData ||
+      !canvas ||
+      !tsPts ||
+      subtitleEnabled === false ||
+      isPlaying === false
+    )
+      return
+    const decoded = tryBase64ToUint8Array(aribSubtitleData.data)
+    if (!decoded) return
+    const fromZero = ((aribSubtitleData.pts * 9) / 100 - tsPts[1]) / 90_000
+    const pts = fromZero - playingTime / 1000
+    const provider = new CanvasProvider(decoded, pts)
+    const estimate = provider.render()
+    if (!estimate) return
+    const ctx = canvas.getContext("2d")
+    if (!ctx) return
+    setTimeout(() => {
+      ctx.clearRect(0, 0, canvas.width, canvas.height)
+      provider.render({
+        canvas,
+        width: 1920,
+        height: 1080,
+        useStrokeText: true,
+      })
+      setDisplayingAribSubtitleData(decoded)
+      displayingSubtitle.current = aribSubtitleData.data
+      if (estimate.endTime === Number.MAX_SAFE_INTEGER) return
+      setTimeout(() => {
+        if (displayingSubtitle.current !== aribSubtitleData.data) return
+        ctx.clearRect(0, 0, canvas.width, canvas.height)
+        displayingSubtitle.current = ""
+        setDisplayingAribSubtitleData(null)
+      }, (estimate.endTime - estimate.startTime) * 1000)
+    }, estimate.startTime * 1000)
+  }, [aribSubtitleData])
+
+  return (
+    <canvas
+      width={1920}
+      height={1080}
+      className="absolute top-0 left-0 pointer-events-none w-full"
+      style={{ height }}
+      ref={canvasRef}
+    ></canvas>
+  )
+})

--- a/src/components/mainPlayer/SubtitleRenderer.tsx
+++ b/src/components/mainPlayer/SubtitleRenderer.tsx
@@ -11,6 +11,7 @@ import {
 import { CanvasProvider } from "aribb24.js"
 import { tryBase64ToUint8Array } from "../../utils/string"
 import { useRefFromState } from "../../hooks/ref"
+import clsx from "clsx"
 
 export const CoiledSubtitleRenderer: React.VFC<{}> = memo(({}) => {
   const canvasRef = useRef<HTMLCanvasElement>(null)
@@ -94,7 +95,11 @@ export const CoiledSubtitleRenderer: React.VFC<{}> = memo(({}) => {
     <canvas
       width={1920}
       height={1080}
-      className="pointer-events-none w-full"
+      className={clsx(
+        "pointer-events-none",
+        "w-full",
+        !subtitleEnabled && "opacity-0"
+      )}
       style={{ height }}
       ref={canvasRef}
     ></canvas>

--- a/src/components/mainPlayer/SubtitleRenderer.tsx
+++ b/src/components/mainPlayer/SubtitleRenderer.tsx
@@ -78,6 +78,8 @@ export const CoiledSubtitleRenderer: React.VFC<{}> = memo(({}) => {
         canvas,
         useStrokeText: true,
         keepAspectRatio: true,
+        normalFont: "'Rounded M+ 1m for ARIB'",
+        gaijiFont: "'Rounded M+ 1m for ARIB'",
       })
       setDisplayingAribSubtitleData(decoded)
       displayingSubtitle.current = aribSubtitleData.data

--- a/src/components/mainPlayer/VideoPlayer.tsx
+++ b/src/components/mainPlayer/VideoPlayer.tsx
@@ -6,13 +6,17 @@ import { useRecoilState, useRecoilValue, useSetRecoilState } from "recoil"
 import WebChimeraJs from "webchimera.js"
 import { toast } from "react-toastify"
 import {
+  mainPlayerAribSubtitleData,
   mainPlayerAudioChannel,
   mainPlayerAudioTrack,
   mainPlayerAudioTracks,
+  mainPlayerDisplayingAribSubtitleData,
   mainPlayerIsPlaying,
+  mainPlayerPlayingTime,
   mainPlayerScreenshotTrigger,
   mainPlayerSelectedService,
   mainPlayerSubtitleEnabled,
+  mainPlayerTsPts,
   mainPlayerUrl,
   mainPlayerVolume,
 } from "../../atoms/mainPlayer"
@@ -20,6 +24,7 @@ import { VideoRenderer } from "../../utils/videoRenderer"
 import { VLCLogFilter } from "../../utils/vlc"
 import { screenshotSetting } from "../../atoms/settings"
 import dayjs from "dayjs"
+import { CanvasProvider } from "aribb24.js"
 
 export const CoiledVideoPlayer: React.VFC<{}> = memo(() => {
   const canvasRef = useRef<HTMLCanvasElement>(null)
@@ -101,6 +106,10 @@ export const CoiledVideoPlayer: React.VFC<{}> = memo(() => {
   }, [])
   const selectedService = useRecoilValue(mainPlayerSelectedService)
 
+  const displayingAribSubtitleData = useRecoilValue(
+    mainPlayerDisplayingAribSubtitleData
+  )
+
   // スクリーンショットフォルダ初期設定
   const screenshotTrigger = useRecoilValue(mainPlayerScreenshotTrigger)
   useEffect(() => {
@@ -114,6 +123,18 @@ export const CoiledVideoPlayer: React.VFC<{}> = memo(() => {
         const context = canvas.getContext("2d", { alpha: false })
         if (!context) throw new Error("ctx")
         context.drawImage(glCanvas, 0, 0, canvas.width, canvas.height)
+        if (displayingAribSubtitleData && screenshot.includeSubtitle === true) {
+          const subtitleCanvas = document.createElement("canvas")
+          subtitleCanvas.height = canvas.height
+          subtitleCanvas.width = canvas.width
+          const provider = new CanvasProvider(displayingAribSubtitleData, 0)
+          provider.render({
+            canvas: subtitleCanvas,
+            width: canvas.width,
+            height: canvas.height,
+          })
+          context.drawImage(subtitleCanvas, 0, 0, canvas.width, canvas.height)
+        }
         const blob = await new Promise<Blob | null>((res) =>
           canvas.toBlob((blob) => res(blob), "image/png", 1)
         )
@@ -158,6 +179,10 @@ export const CoiledVideoPlayer: React.VFC<{}> = memo(() => {
     })()
   }, [screenshotTrigger])
 
+  const setAribSubtitleData = useSetRecoilState(mainPlayerAribSubtitleData)
+  const setTsPts = useSetRecoilState(mainPlayerTsPts)
+  const setPlayingTime = useSetRecoilState(mainPlayerPlayingTime)
+
   useEffect(() => {
     const renderContext = new VideoRenderer(canvasRef.current!, {
       preserveDrawingBuffer: true,
@@ -176,6 +201,15 @@ export const CoiledVideoPlayer: React.VFC<{}> = memo(() => {
         case "successfully_opened":
           setIsPlaying(true)
           setSubtitleEnabled(false)
+          break
+        case "arib_data":
+          setPlayingTime(player.time)
+          parsed.data &&
+            setAribSubtitleData({ data: parsed.data, pts: parsed.pts })
+          break
+        case "i_pcr":
+          setPlayingTime(player.time)
+          parsed.i_pcr && setTsPts([parsed.i_pcr, parsed.pcr_i_first])
           break
         case "received_first_picture":
         case "es_out_program_epg":

--- a/src/components/mainPlayer/VideoPlayer.tsx
+++ b/src/components/mainPlayer/VideoPlayer.tsx
@@ -212,6 +212,7 @@ export const CoiledVideoPlayer: React.VFC<{}> = memo(() => {
           break
         case "successfully_opened":
           setIsPlaying(true)
+          setSubtitleEnabled(false)
           break
         case "arib_parser_was_destroyed":
           setSubtitleEnabled(false)

--- a/src/components/mainPlayer/VideoPlayer.tsx
+++ b/src/components/mainPlayer/VideoPlayer.tsx
@@ -220,13 +220,17 @@ export const CoiledVideoPlayer: React.VFC<{}> = memo(() => {
           setSubtitleEnabled(false)
           break
         case "arib_data":
+          console.log(message)
           setPlayingTime(player.time)
-          parsed.data &&
+          if (parsed.data) {
             setAribSubtitleData({ data: parsed.data, pts: parsed.pts })
+          }
           break
         case "i_pcr":
           setPlayingTime(player.time)
-          parsed.i_pcr && setTsPts([parsed.i_pcr, parsed.pcr_i_first])
+          if (parsed.i_pcr) {
+            setTsPts([parsed.i_pcr, parsed.pcr_i_first])
+          }
           break
         case "received_first_picture":
         case "es_out_program_epg":

--- a/src/components/mainPlayer/VideoPlayer.tsx
+++ b/src/components/mainPlayer/VideoPlayer.tsx
@@ -212,6 +212,8 @@ export const CoiledVideoPlayer: React.VFC<{}> = memo(() => {
           break
         case "successfully_opened":
           setIsPlaying(true)
+          break
+        case "arib_parser_was_destroyed":
           setSubtitleEnabled(false)
           break
         case "arib_data":

--- a/src/components/mainPlayer/VideoPlayer.tsx
+++ b/src/components/mainPlayer/VideoPlayer.tsx
@@ -138,6 +138,8 @@ export const CoiledVideoPlayer: React.VFC<{}> = memo(() => {
             canvas: subtitleCanvas,
             useStrokeText: true,
             keepAspectRatio: true,
+            normalFont: "'Rounded M+ 1m for ARIB'",
+            gaijiFont: "'Rounded M+ 1m for ARIB'",
           })
           context.drawImage(
             subtitleCanvas,

--- a/src/components/mainPlayer/VideoPlayer.tsx
+++ b/src/components/mainPlayer/VideoPlayer.tsx
@@ -113,30 +113,42 @@ export const CoiledVideoPlayer: React.VFC<{}> = memo(() => {
   // スクリーンショットフォルダ初期設定
   const screenshotTrigger = useRecoilValue(mainPlayerScreenshotTrigger)
   useEffect(() => {
-    if (!screenshotTrigger || !canvasRef.current) return
+    const canvas = canvasRef.current
+    if (!screenshotTrigger || !canvas) return
     ;(async () => {
       try {
-        const glCanvas = canvasRef.current!
-        const canvas = document.createElement("canvas")
-        canvas.height = glCanvas.height
-        canvas.width = Math.ceil(glCanvas.height / aspect)
-        const context = canvas.getContext("2d", { alpha: false })
+        const contentCanvas = document.createElement("canvas")
+        contentCanvas.height = canvas.height
+        contentCanvas.width = Math.ceil(canvas.height / aspect)
+        const context = contentCanvas.getContext("2d", { alpha: false })
         if (!context) throw new Error("ctx")
-        context.drawImage(glCanvas, 0, 0, canvas.width, canvas.height)
+        context.drawImage(
+          canvas,
+          0,
+          0,
+          contentCanvas.width,
+          contentCanvas.height
+        )
         if (displayingAribSubtitleData && screenshot.includeSubtitle === true) {
           const subtitleCanvas = document.createElement("canvas")
-          subtitleCanvas.height = canvas.height
-          subtitleCanvas.width = canvas.width
+          subtitleCanvas.height = contentCanvas.height
+          subtitleCanvas.width = contentCanvas.width
           const provider = new CanvasProvider(displayingAribSubtitleData, 0)
           provider.render({
             canvas: subtitleCanvas,
-            width: canvas.width,
-            height: canvas.height,
+            useStrokeText: true,
+            keepAspectRatio: true,
           })
-          context.drawImage(subtitleCanvas, 0, 0, canvas.width, canvas.height)
+          context.drawImage(
+            subtitleCanvas,
+            0,
+            0,
+            contentCanvas.width,
+            contentCanvas.height
+          )
         }
         const blob = await new Promise<Blob | null>((res) =>
-          canvas.toBlob((blob) => res(blob), "image/png", 1)
+          contentCanvas.toBlob((blob) => res(blob), "image/png", 1)
         )
         if (!blob) throw new Error("blob")
         try {

--- a/src/components/settings/general/Screenshot.tsx
+++ b/src/components/settings/general/Screenshot.tsx
@@ -10,13 +10,16 @@ export const ScreenshotSettingForm: React.VFC<{
   setScreenshotSetting: React.Dispatch<React.SetStateAction<ScreenshotSetting>>
 }> = ({ screenshotSetting, setScreenshotSetting }) => {
   const [saveAsAFile, setSaveAsAFile] = useState(screenshotSetting.saveAsAFile)
+  const [includeSubtitle, setIncludeSubtitle] = useState(
+    screenshotSetting.includeSubtitle
+  )
   const [basePath, setBasePath] = useState(screenshotSetting.basePath)
   useDebounce(
     () => {
-      setScreenshotSetting({ saveAsAFile, basePath })
+      setScreenshotSetting({ saveAsAFile, basePath, includeSubtitle })
     },
     100,
-    [saveAsAFile, basePath]
+    [saveAsAFile, basePath, includeSubtitle]
   )
   return (
     <div>
@@ -28,6 +31,15 @@ export const ScreenshotSettingForm: React.VFC<{
           className="block mt-2 form-checkbox"
           checked={saveAsAFile || false}
           onChange={() => setSaveAsAFile((enabled) => !enabled)}
+        />
+      </label>
+      <label className="block mt-4">
+        <span>スクリーンショットに字幕を含める</span>
+        <input
+          type="checkbox"
+          className="block mt-2 form-checkbox"
+          checked={includeSubtitle || false}
+          onChange={() => setIncludeSubtitle((enabled) => !enabled)}
         />
       </label>
       <label className="mt-4 mb-2 block">

--- a/src/types/setting.ts
+++ b/src/types/setting.ts
@@ -15,6 +15,7 @@ export type ControllerSetting = {
 
 export type ScreenshotSetting = {
   saveAsAFile: boolean
+  includeSubtitle: boolean
   basePath?: string
 }
 

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -1,0 +1,8 @@
+export const tryBase64ToUint8Array = (s: string) => {
+  try {
+    return Uint8Array.from(atob(s), (c) => c.charCodeAt(0))
+  } catch (error) {
+    console.error(error)
+    return false
+  }
+}

--- a/src/utils/vlc.ts
+++ b/src/utils/vlc.ts
@@ -39,6 +39,22 @@ export const VLCLogFilter = (s: string) => {
       category: "psz_subtitle_data",
       array: Uint8Array.from(m[1].split(" ").map((s) => parseInt(`0x${s}`))),
     } as const
+  } else if (s.startsWith("arib_data")) {
+    const m = s.match(/^arib_data \[(.+)\]\[(\d+)\]$/)
+    if (!m) return { category: "arib_data" } as const
+    return {
+      category: "arib_data",
+      data: m[1],
+      pts: parseInt(m[2]),
+    }
+  } else if (s.startsWith("i_pcr")) {
+    const m = s.match(/^i_pcr \[(\d+)\]\[(\d+)\]$/)
+    if (!m) return { category: "i_pcr" }
+    return {
+      category: "i_pcr",
+      i_pcr: parseInt(m[1]),
+      pcr_i_first: parseInt(m[2]),
+    }
   } else if (s.startsWith("VLC is unable to open the MRL")) {
     return { category: "unable_to_open" } as const
   } else if (s.includes("successfully opened")) {

--- a/src/utils/vlc.ts
+++ b/src/utils/vlc.ts
@@ -55,6 +55,8 @@ export const VLCLogFilter = (s: string) => {
       i_pcr: parseInt(m[1]),
       pcr_i_first: parseInt(m[2]),
     }
+  } else if (s.startsWith("arib parser was destroyed")) {
+    return { category: "arib_parser_was_destroyed" }
   } else if (s.startsWith("VLC is unable to open the MRL")) {
     return { category: "unable_to_open" } as const
   } else if (s.includes("successfully opened")) {

--- a/src/utils/vlc.ts
+++ b/src/utils/vlc.ts
@@ -32,13 +32,6 @@ export const VLCLogFilter = (s: string) => {
       width: parseInt(width),
       height: parseInt(height),
     } as const
-  } else if (s.startsWith("psz_subtitle_data")) {
-    const m = s.match(/psz_subtitle_data \[(.*)\s\]/)
-    if (!m) return { category: "psz_subtitle_data" } as const
-    return {
-      category: "psz_subtitle_data",
-      array: Uint8Array.from(m[1].split(" ").map((s) => parseInt(`0x${s}`))),
-    } as const
   } else if (s.startsWith("arib_data")) {
     const m = s.match(/^arib_data \[(.+)\]\[(\d+)\]$/)
     if (!m) return { category: "arib_data" } as const
@@ -46,7 +39,7 @@ export const VLCLogFilter = (s: string) => {
       category: "arib_data",
       data: m[1],
       pts: parseInt(m[2]),
-    }
+    } as const
   } else if (s.startsWith("i_pcr")) {
     const m = s.match(/^i_pcr \[(\d+)\]\[(\d+)\]$/)
     if (!m) return { category: "i_pcr" }
@@ -54,9 +47,9 @@ export const VLCLogFilter = (s: string) => {
       category: "i_pcr",
       i_pcr: parseInt(m[1]),
       pcr_i_first: parseInt(m[2]),
-    }
+    } as const
   } else if (s.startsWith("arib parser was destroyed")) {
-    return { category: "arib_parser_was_destroyed" }
+    return { category: "arib_parser_was_destroyed" } as const
   } else if (s.startsWith("VLC is unable to open the MRL")) {
     return { category: "unable_to_open" } as const
   } else if (s.includes("successfully opened")) {

--- a/src/utils/vlc.ts
+++ b/src/utils/vlc.ts
@@ -2,7 +2,8 @@ export const VLCLogFilter = (s: string) => {
   if (
     s.startsWith("picture is too late to be displayed") ||
     s.startsWith("picture might be displayed late") ||
-    s.startsWith("More than")
+    s.startsWith("More than") ||
+    s.startsWith("buffer too late")
   ) {
     return { category: "picture_late_warn" } as const
   } else if (s.startsWith("libdvbpsi error")) {
@@ -52,7 +53,7 @@ export const VLCLogFilter = (s: string) => {
     return { category: "arib_parser_was_destroyed" } as const
   } else if (s.startsWith("VLC is unable to open the MRL")) {
     return { category: "unable_to_open" } as const
-  } else if (s.includes("successfully opened")) {
+  } else if (s.includes("successfully opened") && s.includes("http")) {
     return { category: "successfully_opened" } as const
   } else if (s.startsWith("Received first picture")) {
     return { category: "received_first_picture" } as const

--- a/src/windows/MainPlayer.tsx
+++ b/src/windows/MainPlayer.tsx
@@ -21,6 +21,7 @@ import { mirakurunServices } from "../atoms/mirakurun"
 import { useRefFromState } from "../hooks/ref"
 import { useRecoilValueRef } from "../utils/recoil"
 import { CoiledProgramTitleManager } from "../components/mainPlayer/ProgramTitleManager"
+import { CoiledSubtitleRenderer } from "../components/mainPlayer/SubtitleRenderer"
 
 export const CoiledMainPlayer: React.VFC<{}> = () => {
   const [route, setRoute] = useRecoilState(mainPlayerRoute)
@@ -199,6 +200,9 @@ export const CoiledMainPlayer: React.VFC<{}> = () => {
           </div>
           <div className="absolute top-0 left-0 w-full h-full">
             <CoiledSayaComments />
+          </div>
+          <div className="absolute top-0 left-0 w-full h-full flex items-center justify-center">
+            <CoiledSubtitleRenderer />
           </div>
           <div className="absolute top-0 left-0 w-full h-full">
             <CoiledController />

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -73,6 +73,11 @@ const imageLoaderConfiguration: webpack.RuleSetRule = {
   },
 }
 
+const assetLoaderConfiguration: webpack.RuleSetRule = {
+  test: /\.(ttf)$/,
+  type: "asset/resource",
+}
+
 const factory: MultiConfigurationFactory = (env, args) => [
   {
     entry: path.resolve(__dirname, "./src/index.web.tsx"),
@@ -86,8 +91,9 @@ const factory: MultiConfigurationFactory = (env, args) => [
     module: {
       rules: [
         babelLoaderConfiguration,
-        scssConfiguration,
+        assetLoaderConfiguration,
         imageLoaderConfiguration,
+        scssConfiguration,
         nodeConfiguration,
       ],
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -8016,10 +8016,10 @@ watchpack@^2.0.0:
     glob-to-regexp "^0.4.1"
     graceful-fs "^4.1.2"
 
-webchimera.js@^0.5.1:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/webchimera.js/-/webchimera.js-0.5.1.tgz#135eb2a43ab4b0a4573d0e80681528f4c44c5e65"
-  integrity sha512-orMhdNL/DSRP+1YkqShLgpRYco7WvQmlRh88NwyDoMacSu4rJ4kHo8SinZCKUOkhuyJFVo+FYQ7MGdkKxT7bfg==
+webchimera.js@^0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/webchimera.js/-/webchimera.js-0.5.2.tgz#5a39555d4a40d67bed77c7e99d8e466dce98485a"
+  integrity sha512-EGa2Bm0n2UF9D4+Yu6J5321HQJPlHnqSyakPTUOdMkWA/1pfktJvtzCmWxJQASy1tvgftdAAdiZXarbMY4o4jA==
   dependencies:
     bindings "~1.2.1"
     cmake-js "*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2075,10 +2075,10 @@ argparse@^2.0.1:
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
-aribb24.js@^1.6.9:
-  version "1.6.9"
-  resolved "https://registry.yarnpkg.com/aribb24.js/-/aribb24.js-1.6.9.tgz#8d8647bb04bb8f5639ad31d2e9c11805c21e5f67"
-  integrity sha512-zdqY/Gq78VLe0+pn0A9b/jl7Iig2v7W9QHPugfvTpruncEHJmCbOEO0anKYRwwzr4RMli9Frm7VNrl6VxQ7xsg==
+aribb24.js@^1.6.10:
+  version "1.6.10"
+  resolved "https://registry.yarnpkg.com/aribb24.js/-/aribb24.js-1.6.10.tgz#edcf9f8c2567f6d7bcdc04ad29db4966bcf34b53"
+  integrity sha512-uUm7rw6HzpqdIfKLNg+m1Ks3axV8U/aQniNmKP+nS6iWz7b9cuPOzoZsyqbfYMNlHPXHltC1mpRIox40WER+Uw==
   dependencies:
     spark-md5 "^3.0.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2075,10 +2075,10 @@ argparse@^2.0.1:
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
-aribb24.js@^1.6.8:
-  version "1.6.8"
-  resolved "https://registry.yarnpkg.com/aribb24.js/-/aribb24.js-1.6.8.tgz#eeb1f0b2650f76224301851374500f491a1aeef3"
-  integrity sha512-gChNnbB6tRtFb10i2VLKun1dlKSumQAQfdy7DlEtP25ArFHPRgzDjxSw/oktkohB8EZOG6vZ/w5ELIyJ+HkFRw==
+aribb24.js@^1.6.9:
+  version "1.6.9"
+  resolved "https://registry.yarnpkg.com/aribb24.js/-/aribb24.js-1.6.9.tgz#8d8647bb04bb8f5639ad31d2e9c11805c21e5f67"
+  integrity sha512-zdqY/Gq78VLe0+pn0A9b/jl7Iig2v7W9QHPugfvTpruncEHJmCbOEO0anKYRwwzr4RMli9Frm7VNrl6VxQ7xsg==
   dependencies:
     spark-md5 "^3.0.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2075,6 +2075,13 @@ argparse@^2.0.1:
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
+aribb24.js@^1.6.8:
+  version "1.6.8"
+  resolved "https://registry.yarnpkg.com/aribb24.js/-/aribb24.js-1.6.8.tgz#eeb1f0b2650f76224301851374500f491a1aeef3"
+  integrity sha512-gChNnbB6tRtFb10i2VLKun1dlKSumQAQfdy7DlEtP25ArFHPRgzDjxSw/oktkohB8EZOG6vZ/w5ELIyJ+HkFRw==
+  dependencies:
+    spark-md5 "^3.0.1"
+
 arr-diff@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-4.0.0.tgz#d6461074febfec71e7e15235761a329a5dc7c520"
@@ -7160,6 +7167,11 @@ sourcemap-codec@^1.4.8:
   version "1.4.8"
   resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz#ea804bd94857402e6992d05a38ef1ae35a9ab4c4"
   integrity sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==
+
+spark-md5@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/spark-md5/-/spark-md5-3.0.1.tgz#83a0e255734f2ab4e5c466e5a2cfc9ba2aa2124d"
+  integrity sha512-0tF3AGSD1ppQeuffsLDIOWlKUd3lS92tFxcsrh5Pe3ZphhnoK+oXIBTzOAThZCiuINZLvpiLH/1VS1/ANEJVig==
 
 spdx-correct@^3.0.0:
   version "3.1.1"


### PR DESCRIPTION
とりあえずmacOSのみ対応
- 字幕情報を出力するためにカスタマイズしたVLCを導入
- WindowsもVLCを同梱する仕組みのためおそらく導入可能
- Linuxはグローバルのvlcを使用するので厳しそう
  - ただモジュール制度？があるらしく`vlc-aribsub-miraktest-plugin.so`みたいなのを単体でインストールしてvlcに認識させるとかはできそう
  - https://github.com/johang/vlc-bittorrent かなりめんどくさそう
  - 使いたい人いたらお願いします パッチは [vlc-miraktest](https://github.com/vivid-lapin/vlc-miraktest) にあります
  - よく考えたらオリジナルの字幕を消さなきゃいけないからモジュールの上書きになるか

![image](https://user-images.githubusercontent.com/7887955/119975279-9bb02280-bff0-11eb-8bfc-07230c1b660a.png)
![貼り付けた画像_2021_05_30_19_00](https://user-images.githubusercontent.com/7887955/120100154-2708ef80-c17a-11eb-9a79-d367a6a208fb.jpg)
![image](https://user-images.githubusercontent.com/7887955/120100458-c8dd0c00-c17b-11eb-9c3e-fb42a2a5638c.png)
