### PR TITLE
fix: Windows でもメニューバーを隠す

### DIFF
--- a/src/main/index.electron.ts
+++ b/src/main/index.electron.ts
@@ -732,7 +732,7 @@ const openWindow = ({
         process.platform === "darwin" && name === ROUTES.ContentPlayer
           ? true
           : undefined,
-      autoHideMenuBar: process.platform !== "win32" ? true : undefined,
+      autoHideMenuBar: process.platform === "win32" ? true : undefined,
       ...args,
     })
     const [, contentHeight] = window.getContentSize()


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6058487/184506986-ec0ae0e7-fa27-4247-afc7-4db8c7a32d59.png)
